### PR TITLE
Allow the different ways of specifying a form controller

### DIFF
--- a/ngFormFixes.directive.js
+++ b/ngFormFixes.directive.js
@@ -30,7 +30,9 @@ module.directive('ngForm', function ($parse, $timeout) {
                 e.stopPropagation();
                 
                 $timeout(function () {
-                    $scope[$attrs.ngForm].$submitted = true;
+                    if ($scope[$attrs.ngForm || $attrs.name]) { 
+                        $scope[$attrs.ngForm || $attrs.name].$submitted = true;
+                    }
                     $element.addClass('ng-submitted');
                 });
             }


### PR DESCRIPTION
This will fix a bug that caused an error when a form controller was either not specified or specified with the 'name' attribute, which are both valid cases.

The following valid cases will now work: 

``` html
<div ng-form="formName">
  ...
</div>
```

``` html
<ng-form name="formName">
  ...
</ng-form>
```

``` html
<ng-form>
  ...
</ng-form>
```
