### PR TITLE
Added support for minification

### DIFF
--- a/ngFormFixes.directive.js
+++ b/ngFormFixes.directive.js
@@ -1,6 +1,6 @@
 var module = angular.module('ngFormFixes', []);
 
-module.directive('ngForm', function ($parse, $timeout) {
+module.directive('ngForm', ['$parse', '$timeout', function ($parse, $timeout) {
     return {
         link: linkFunction
     };
@@ -54,7 +54,7 @@ module.directive('ngForm', function ($parse, $timeout) {
         }
     }
 
-});
+}]);
 
 module.directive('onEnter', ['$parse', function ($parse) {
     return {


### PR DESCRIPTION
On minification tools may substitute parameter names. So the array syntax should be used.