### PR TITLE
Fixed Karma unit tests and used strict syntax

### DIFF
--- a/ngFormFixes.directive.js
+++ b/ngFormFixes.directive.js
@@ -1,80 +1,90 @@
-var module = angular.module('ngFormFixes', []);
+'use strict';
 
-module.directive('ngForm', ['$parse', '$timeout', function ($parse, $timeout) {
-    return {
+(function() {
+  angular
+    .module('ngFormFixes', [])
+    .directive('ngForm', ['$parse', '$timeout', function($parse, $timeout) {
+      return {
         link: linkFunction
-    };
+      };
 
-    function linkFunction ($scope, $element, $attrs) {
+      function linkFunction($scope, $element, $attrs) {
 
-        var $submit_button = findSubmitButton();
+        var submitButton = findSubmitButton();
 
         // bind Enter key
-        $element.bind('keydown', function (e) {
-            var keyCode = e.keyCode || e.which;
-            if (keyCode === 13) {
-                var nodeType = e.target.nodeName.toLowerCase();
-                if (nodeType == 'input') {
-                    if ($attrs.ngSubmit) {
-                        $parse($attrs.ngSubmit)($scope, { $event: e });
-                        e.stopPropagation();
-                        e.preventDefault();
-                    } else if ($submit_button) {
-                        $submit_button.click();
-                        e.stopPropagation();
-                        e.preventDefault();
-                    }
-                }
+        $element.bind('keydown', function(e) {
+          var keyCode = e.keyCode || e.which;
+          if (keyCode === 13) {
+            var nodeType = e.target.nodeName.toLowerCase();
+            if (nodeType === 'input') {
+              if ($attrs.ngSubmit) {
+                $parse($attrs.ngSubmit)($scope, {
+                  $event: e
+                });
+                e.stopPropagation();
+                e.preventDefault();
+              } else if (submitButton) {
+                submitButton.click();
+                e.stopPropagation();
+                e.preventDefault();
+              }
             }
+          }
         });
 
         // bind Submit click to run itself or ngSubmit
-        angular.element($submit_button).bind('click', function (e) {
-            if ($attrs.ngSubmit && angular.element(this).attr('ng-click') === undefined) {
-                $parse($attrs.ngSubmit)($scope, { $event: e });
-                e.stopPropagation();
-                e.preventDefault();
-                
-                $timeout(function () {
-                    if ($scope[$attrs.ngForm || $attrs.name]) { 
-                        $scope[$attrs.ngForm || $attrs.name].$submitted = true;
-                    }
-                    $element.addClass('ng-submitted');
-                });
-            }
+        angular.element(submitButton).bind('click', function(e) {
+          if ($attrs.ngSubmit && angular.element(this).attr('ng-click') === undefined) {
+            $parse($attrs.ngSubmit)($scope, {
+              $event: e
+            });
+            e.stopPropagation();
+            e.preventDefault();
+
+            $timeout(function() {
+              if ($scope[$attrs.ngForm || $attrs.name]) {
+                $scope[$attrs.ngForm || $attrs.name].$submitted = true;
+              }
+              $element.addClass('ng-submitted');
+            });
+          }
         });
 
         // internal
-        function findSubmitButton () {
-            var $buttons = [$element.find('button'), $element.find('input')];
+        function findSubmitButton() {
+          var $buttons = [$element.find('button'), $element.find('input')];
 
-            for (var i = 0; i < $buttons.length; i++) {
-                for (var n = 0; n < $buttons[i].length; n++) {
-                    var $current = $buttons[i][n];
-                    if ($current.getAttribute('type') && $current.getAttribute('type').toLowerCase() === 'submit') {
-                        return $current;
-                    }
+          for (var i = 0; i < $buttons.length; i++) {
+            for (var n = 0; n < $buttons[i].length; n++) {
+              var $current = $buttons[i][n];
+              if ($current.getAttribute('type') && $current.getAttribute('type').toLowerCase() === 'submit') {
+                return $current;
+              }
 
-                }
             }
+          }
         }
-    }
+      }
 
-}]);
+    }])
 
-module.directive('onEnter', ['$parse', function ($parse) {
+  .directive('onEnter', ['$parse', function($parse) {
     return {
-        link: function ($scope, $element, $attrs) {
+      link: function($scope, $element, $attrs) {
 
-            $element.bind('keyup', function (e) {
+        $element.bind('keyup', function(e) {
 
-                var keyCode = e.keyCode || e.which;
+          var keyCode = e.keyCode || e.which;
 
-                if (keyCode === 13 && $attrs.onEnter) {
-                    $parse($attrs.onEnter)($scope, { $event: e });
-                }
-
+          if (keyCode === 13 && $attrs.onEnter) {
+            $parse($attrs.onEnter)($scope, {
+              $event: e
             });
-        }
+          }
+
+        });
+      }
     };
-}]);
+  }]);
+})();


### PR DESCRIPTION
Very useful directive, but using this broke my Karma/Jasmine unit tests because it redeclared the global variable `module`. Got rid of the variable and formatted to add `use script` syntax (http://stackoverflow.com/questions/1335851/what-does-use-strict-do-in-javascript-and-what-is-the-reasoning-behind-it).